### PR TITLE
Fix up test_json_serialization to work under alternate runners

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -23,7 +23,7 @@ class ErrorsTest(FaunaTestCase):
     self.assertEqual(rr.response_raw, "I like fine wine")
 
   def test_json_serialization(self):
-    msg = "Unserializable object TestObj of type <class 'tests.test_errors.TestObj'"
+    msg = r"Unserializable object TestObj of type <class '(tests\.)?test_errors\.TestObj'>"
     self.assertRaisesRegexCompat(UnexpectedError, msg, lambda: self.client.query(TestObj()))
 
   def test_resource_error(self):


### PR DESCRIPTION
Aka "I wanted to run this to run under IntelliJ and it was incorrectly failing".