### PR TITLE
Support for @bytes type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.2.dev1
 
 - Added `key_for_secret` and `at` query functions
-- Added `@bytes` type support (via `bytes` for Python 3.x and `bytearray` for Python 2.x)
+- Added `@bytes` type support (via `bytearray`)
 
 ## 0.1.1 (December 6, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.2.dev1
 
 - Added `key_for_secret` and `at` query functions
+- Added `@bytes` type support (via `bytes` for Python 3.x and `bytearray` for Python 2.x)
 
 ## 0.1.1 (December 6, 2016)
 

--- a/faunadb/_json.py
+++ b/faunadb/_json.py
@@ -1,3 +1,5 @@
+import sys
+from base64 import urlsafe_b64decode, urlsafe_b64encode
 from datetime import date, datetime
 from json import dumps, loads, JSONEncoder
 from iso8601 import parse_date
@@ -36,6 +38,11 @@ def _parse_json_hook(dct):
     return FaunaTime(dct["@ts"])
   if "@date" in dct:
     return parse_date(dct["@date"]).date()
+  if "@bytes" in dct:
+    if sys.version_info.major == 2:
+      return bytearray(urlsafe_b64decode(dct["@bytes"].encode()))
+    else:
+      return urlsafe_b64decode(dct["@bytes"])
   else:
     return dct
 
@@ -61,5 +68,9 @@ class _FaunaJSONEncoder(JSONEncoder):
       return FaunaTime(obj).to_fauna_json()
     elif isinstance(obj, date):
       return {"@date": obj.isoformat()}
+    elif sys.version_info.major == 2 and isinstance(obj, bytearray):
+      return {"@bytes": urlsafe_b64encode(obj)}
+    elif sys.version_info.major == 3 and isinstance(obj, (bytes, bytearray)):
+      return {"@bytes": urlsafe_b64encode(obj).decode('utf-8')}
     else:
       raise UnexpectedError("Unserializable object {} of type {}".format(obj, type(obj)), None)

--- a/faunadb/_json.py
+++ b/faunadb/_json.py
@@ -1,4 +1,3 @@
-import sys
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from datetime import date, datetime
 from json import dumps, loads, JSONEncoder
@@ -39,10 +38,7 @@ def _parse_json_hook(dct):
   if "@date" in dct:
     return parse_date(dct["@date"]).date()
   if "@bytes" in dct:
-    if sys.version_info.major == 2:
-      return bytearray(urlsafe_b64decode(dct["@bytes"].encode()))
-    else:
-      return urlsafe_b64decode(dct["@bytes"])
+    return bytearray(urlsafe_b64decode(dct["@bytes"].encode()))
   else:
     return dct
 
@@ -68,9 +64,7 @@ class _FaunaJSONEncoder(JSONEncoder):
       return FaunaTime(obj).to_fauna_json()
     elif isinstance(obj, date):
       return {"@date": obj.isoformat()}
-    elif sys.version_info.major == 2 and isinstance(obj, bytearray):
-      return {"@bytes": urlsafe_b64encode(obj)}
-    elif sys.version_info.major == 3 and isinstance(obj, (bytes, bytearray)):
+    elif isinstance(obj, (bytes, bytearray)):
       return {"@bytes": urlsafe_b64encode(obj).decode('utf-8')}
     else:
       raise UnexpectedError("Unserializable object {} of type {}".format(obj, type(obj)), None)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,4 +1,3 @@
-import sys
 from unittest import TestCase
 from iso8601 import parse_date
 
@@ -23,10 +22,7 @@ class DeserializationTest(TestCase):
     self.assertJson('{"@date":"1970-01-01"}', parse_date("1970-01-01").date())
 
   def test_bytes(self):
-    if sys.version_info.major == 2:
-      self.assertJson('{"@bytes":"AQID"}', bytearray(b'\x01\x02\x03'))
-    else:
-      self.assertJson('{"@bytes":"AQID"}', b'\x01\x02\x03')
+    self.assertJson('{"@bytes":"AQID"}', bytearray(b'\x01\x02\x03'))
 
   def test_string(self):
     self.assertJson('"a string"', "a string")

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import TestCase
 from iso8601 import parse_date
 
@@ -20,6 +21,12 @@ class DeserializationTest(TestCase):
 
   def test_date(self):
     self.assertJson('{"@date":"1970-01-01"}', parse_date("1970-01-01").date())
+
+  def test_bytes(self):
+    if sys.version_info.major == 2:
+      self.assertJson('{"@bytes":"AQID"}', bytearray(b'\x01\x02\x03'))
+    else:
+      self.assertJson('{"@bytes":"AQID"}', b'\x01\x02\x03')
 
   def test_string(self):
     self.assertJson('"a string"', "a string")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -24,9 +24,10 @@ class SerializationTest(TestCase):
                     '{"@ts":"1970-01-01T00:00:00Z"}')
 
   def test_bytes(self):
-    if sys.version_info.major == 3:
-      self.assertJson(b'\x01\x02\x03', '{"@bytes":"AQID"}')
     self.assertJson(bytearray(b'\x01\x02\x03'), '{"@bytes":"AQID"}')
+    if sys.version_info.major == 3:
+      # In Python 3.x we should also accept bytes
+      self.assertJson(b'\x01\x02\x03', '{"@bytes":"AQID"}')
 
   #region Basic forms
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,7 @@
+import iso8601
+import sys
 from unittest import TestCase
 from datetime import datetime
-import iso8601
 
 from faunadb import query
 from faunadb.objects import Ref, SetRef, FaunaTime
@@ -21,6 +22,11 @@ class SerializationTest(TestCase):
                     '{"@ts":"1970-01-01T00:00:00.123456789Z"}')
     self.assertJson(datetime.fromtimestamp(0, iso8601.UTC),
                     '{"@ts":"1970-01-01T00:00:00Z"}')
+
+  def test_bytes(self):
+    if sys.version_info.major == 3:
+      self.assertJson(b'\x01\x02\x03', '{"@bytes":"AQID"}')
+    self.assertJson(bytearray(b'\x01\x02\x03'), '{"@bytes":"AQID"}')
 
   #region Basic forms
 


### PR DESCRIPTION
I'm not sure how I feel about this, but this is an implementation of `@bytes` support for Python without using a wrapper. In Python 2.x, objects of the type `bytearray` are encoded as `@bytes` and are then decoded as `bytearray`. In Python 3.x, objects of the type `bytes` or `bytearray` are encoded as `@bytes`, and are then decoded as `bytes`.

Part of https://github.com/faunadb/sales-engineering/issues/436.
Fixes https://github.com/faunadb/sales-engineering/issues/509.