### PR TITLE
DRV-88: Fix None query timeout on FaunaClient constructor

### DIFF
--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -138,9 +138,10 @@ class FaunaClient(object):
         "Accept-Encoding": "gzip",
         "Content-Type": "application/json;charset=utf-8",
         "X-Fauna-Driver": "python",
-        "X-FaunaDB-API-Version": API_VERSION,
-        "X-Query-Timeout": str(self._query_timeout_ms)
+        "X-FaunaDB-API-Version": API_VERSION
       })
+      if self._query_timeout_ms is not None:
+        self.session.headers["X-Query-Timeout"] = str(self._query_timeout_ms)
       self.session.timeout = timeout
     else:
       self.session = kwargs['session']
@@ -227,7 +228,7 @@ class FaunaClient(object):
     headers = {}
 
     if query_timeout_ms is not None:
-      headers.add("X-Query-Timeout", str(query_timeout_ms))
+      headers["X-Query-Timeout"] = str(query_timeout_ms)
 
     if with_txn_time:
         headers.update(self._last_txn_time.request_header)


### PR DESCRIPTION
Error:

```bash
In [4]: client = FaunaClient(secret="**********",domain="localhost",scheme="http",port=8443)
In [5]: 
In [5]: client.query(q.paginate(q.indexes()))
---------------------------------------------------------------------------
BadRequest                                Traceback (most recent call last)
<ipython-input-5-a0296a89aeb8> in <module>()
----> 1 client.query(q.paginate(q.indexes()))
/home/*/git/faunadb-python/faunadb/client.pyc in query(self, expression, timeout_millis)
    185     :return: Converted JSON response.
    186     """
--> 187     return self._execute("POST", "", _wrap(expression), with_txn_time=True, query_timeout_ms=timeout_millis)
    188 
    189   def ping(self, scope=None, timeout=None):
/home/*/git/faunadb-python/faunadb/client.pyc in _execute(self, action, path, data, query, with_txn_time, query_timeout_ms)
    256       raise UnexpectedError("Invalid JSON.", request_result)
    257 
--> 258     FaunaError.raise_for_status_code(request_result)
    259     return _get_or_raise(request_result, response_content, "resource")
    260 
/home/*/git/faunadb-python/faunadb/errors.pyc in raise_for_status_code(request_result)
     26       pass
     27     elif code == codes.bad_request:
---> 28       raise BadRequest(request_result)
     29     elif code == codes.unauthorized:
     30       raise Unauthorized(request_result)
BadRequest: Bad value for X-Query-Timeout: For input string: "None"
```
