### PR TITLE
Add third party auth functions.

### DIFF
--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -12,7 +12,7 @@ from faunadb.query import _wrap
 from faunadb.request_result import RequestResult
 from faunadb._json import parse_json_or_none, to_json
 
-API_VERSION = "3"
+API_VERSION = "4"
 
 class _LastTxnTime(object):
   """Wraps tracking the last transaction time supplied from the database."""

--- a/faunadb/objects.py
+++ b/faunadb/objects.py
@@ -84,6 +84,7 @@ class Native(object):
   TOKENS = Ref('tokens')
   CREDENTIALS = Ref('credentials')
   ROLES = Ref('roles')
+  ACCESS_PROVIDERS = Ref('access_providers')
 
   def __init__(self):
     raise TypeError

--- a/faunadb/query.py
+++ b/faunadb/query.py
@@ -63,6 +63,10 @@ def roles(scope=None):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/roles>`__."""
   return _fn({"roles": scope})
 
+def access_providers(scope=None):
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/access_providers>`__."""
+  return _fn({"access_providers": scope})
+
 def keys(scope=None):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/keys>`__."""
   return _fn({"keys": scope})
@@ -425,6 +429,10 @@ def create_role(func_params):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/createrole>`__."""
   return _fn({"create_role": func_params})
 
+def create_access_provider(provider_params):
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/createaccessprovider>`__."""
+  return _fn({"create_access_provider": provider_params})
+
 def move_database(from_, to):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/movedatabase>`__."""
   return _fn({"move_database": from_, "to": to})
@@ -518,10 +526,30 @@ def identify(ref_, password):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/identify>`__."""
   return _fn({"identify": ref_, "password": password})
 
-
+@deprecated("Use `current_identity` instead")
 def identity():
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/identity>`__."""
   return _fn({"identity": None})
+
+
+def current_identity():
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/current_identity>`__."""
+  return _fn({"current_identity": None})
+
+
+def has_current_identity():
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/has_current_identity>`__."""
+  return _fn({"has_current_identity": None})
+
+
+def current_token():
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/current_token>`__."""
+  return _fn({"current_token": None})
+
+
+def has_current_token():
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/has_current_token>`__."""
+  return _fn({"has_current_token": None})
 
 
 def has_identity():
@@ -742,6 +770,11 @@ def function(fn_name, scope=None):
 def role(role_name, scope=None):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/role>`__."""
   return _params({"role": role_name}, {"scope": scope})
+
+
+def access_provider(access_provider_name, scope=None):
+  """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/access_provider>`__."""
+  return _params({"access_provider": access_provider_name}, {"scope": scope})
 
 
 def equals(*values):

--- a/tests/test_3rdpartyauth.py
+++ b/tests/test_3rdpartyauth.py
@@ -1,0 +1,155 @@
+from __future__ import division
+from datetime import date, datetime
+from time import sleep, time
+import string
+import random
+
+
+from faunadb.errors import BadRequest, NotFound, FaunaError, PermissionDenied
+from faunadb.objects import FaunaTime,  Ref, SetRef, _Expr, Native, Query
+from faunadb import query
+from tests.helpers import FaunaTestCase
+
+
+class ThirdPartyAuthTest(FaunaTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(ThirdPartyAuthTest, cls).setUpClass()
+        cls.collection_ref = cls._q(query.create_collection(
+            {"name": "3rdpartyauth_test_coll"}))["ref"]
+
+    #region Helpers
+
+    @classmethod
+    def _create(cls, n=0, **data):
+        data["n"] = n
+        return cls._q(query.create(cls.collection_ref, {"data": data}))
+
+    @classmethod
+    def _q(cls, query_json):
+        return cls.client.query(query_json)
+
+    @classmethod
+    def _randStr(cls, n=10):
+        letters = string.ascii_letters
+        return ''.join(random.choice(letters) for i in range(n))
+
+    def _assert_insufficient_permissions(self, q):
+        self.assertRaises(PermissionDenied, lambda: self._q(q))
+
+    def test_create_access_providers(self):
+        providerName = 'provider_'
+        issuerName = 'issuer_'
+        jwksUri = 'https://xxx.auth0.com/somewhere'
+        provider = self.admin_client.query(query.create_access_provider(
+            {"name": providerName, "issuer": issuerName, "jwks_uri": jwksUri}))
+        self.assertTrue(self.admin_client.query(
+            query.exists(query.access_provider(providerName))))
+        self.assertEqual(provider["name"], providerName)
+        self.assertEqual(provider["issuer"], issuerName)
+        self.assertEqual(provider["jwks_uri"], jwksUri)
+
+        #fails if already exists
+        self.assertRaises(BadRequest, lambda: self.admin_client.query(query.create_access_provider(
+            {"name": providerName, "issuer": issuerName, "jwks_uri": jwksUri})))
+
+        #fails without issuer
+        self.assertRaises(BadRequest, lambda: self.admin_client.query(query.create_access_provider(
+            {"name": providerName, "jwks_uri": jwksUri})))
+
+        #fails with invalid uri
+        jwksUri = 'https:/invalid-uri'
+        self.assertRaises(BadRequest, lambda: self.admin_client.query(query.create_access_provider(
+            {"name": providerName, "issuer": issuerName, "jwks_uri": jwksUri})))
+
+
+    def test_access_provider(self):
+        self.assertEqual(self._q(query.access_provider("pvd-name")),
+                         Ref("pvd-name", Native.ACCESS_PROVIDERS))
+
+    def test_access_providers(self):
+        for i in range(10):
+            providerName = 'provider_%d'%(i)
+            issuerName = 'issuer_%d'%(i)
+            jwksUri = 'https://xxx.auth0.com/uri%d'%(i)
+            obj = {"name": providerName,
+                   "issuer": issuerName, "jwks_uri": jwksUri}
+            self.admin_client.query(query.create_access_provider(obj))
+        self.assertEqual(self.admin_client.query(query.count(query.access_providers())), 10)
+        self._assert_insufficient_permissions(query.paginate(query.access_providers()))
+
+    def test_identity_has_identity(self):
+        instance_ref = self.client.query(
+        query.create(self.collection_ref, {"credentials": {"password": "sekrit"}}))["ref"]
+        secret = self.client.query(
+        query.login(instance_ref, {"password": "sekrit"}))["secret"]
+        instance_client = self.client.new_session_client(secret=secret)
+
+        self.assertTrue(instance_client.query(query.has_current_identity()))
+        self.assertEqual(instance_client.query(query.current_identity()), instance_ref)
+
+    def test_has_current_token(self):
+        instance_ref = self._q(
+            query.create(self.collection_ref, {"credentials": {"password": "sekrit"}}))["ref"]
+        secret = self._q(
+            query.login(instance_ref, {"password": "sekrit"}))["secret"]
+        instance_client = self.client.new_session_client(secret=secret)
+
+        self.assertTrue(instance_client.query(query.has_current_token()))
+        self.assertFalse(self._q(query.has_current_token()))
+
+    def test_has_current_identity(self):
+        instance_ref = self._q(
+            query.create(self.collection_ref, {"credentials": {"password": "sekrit"}}))["ref"]
+        secret = self._q(
+            query.login(instance_ref, {"password": "sekrit"}))["secret"]
+        instance_client = self.client.new_session_client(secret=secret)
+
+        self.assertTrue(instance_client.query(query.has_current_identity()))
+        self.assertFalse(self._q(query.has_current_identity()))
+
+    def test_create_accprov_with_roles(self):
+        providerName = "provider_with_roles"
+        issuerName = "issuer_%s"%(self._randStr())
+        fullUri = "https: //$%s.auth0.com"%(self._randStr(4))
+        roleOneName = "role_one_%s"%(self._randStr(4))
+        roleTwoName = "role_two_%s"%(self._randStr(4))
+
+        self.admin_client.query(query.create_role({
+            "name": roleOneName,
+            "privileges": [
+                {
+                    "resource": query.databases(),
+                    "actions": {"read": True},
+                },
+            ],
+        }))
+
+        self.admin_client.query(query.create_role({
+            "name": roleTwoName,
+            "privileges": [
+                {
+                    "resource": query.databases(),
+                    "actions": {"read": True},
+                },
+            ],
+        }))
+
+        provider = self.admin_client.query(query.create_access_provider({
+            "name": providerName,
+            "issuer": issuerName,
+            "jwks_uri": fullUri,
+            "roles": [
+                query.role(roleOneName),
+                {
+                    "role": query.role(roleTwoName),
+                    "predicate": query.query(query.lambda_("x", True)),
+                },
+            ],
+        }))
+
+        self.assertEqual(provider["name"], providerName)
+        self.assertEqual(provider["issuer"], issuerName)
+        self.assertEqual(provider["jwks_uri"], fullUri)
+        self.assertTrue(isinstance(provider["roles"], list))
+

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -66,7 +66,7 @@ class QueryTest(FaunaTestCase):
     body212 = self._q(versioned212)
 
     body3 = self._q(query.query(lambda a, b: query.concat([a, b], "/")))
-    versioned3 = Query({"api_version": "3", "lambda": ["a", "b"], "expr": {
+    versioned3 = Query({"api_version": "4", "lambda": ["a", "b"], "expr": {
                        "concat": [{"var": "a"}, {"var": "b"}], "separator": "/"}})
 
     self.assertEqual(body212, versioned212)
@@ -556,15 +556,6 @@ class QueryTest(FaunaTestCase):
       query.create(self.collection_ref, {"credentials": {"password": "sekrit"}}))["ref"]
     self.assertTrue(self.client.query(query.identify(instance_ref, "sekrit")))
 
-  def test_identity_has_identity(self):
-    instance_ref = self.client.query(
-      query.create(self.collection_ref, {"credentials": {"password": "sekrit"}}))["ref"]
-    secret = self.client.query(
-      query.login(instance_ref, {"password": "sekrit"}))["secret"]
-    instance_client = self.client.new_session_client(secret=secret)
-
-    self.assertTrue(instance_client.query(query.has_identity()))
-    self.assertEqual(instance_client.query(query.identity()), instance_ref)
 
   #endregion
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,6 +15,7 @@ class SerializationTest(TestCase):
     self.assertJson(Native.DATABASES, '{"@ref":{"id":"databases"}}')
     self.assertJson(Native.FUNCTIONS, '{"@ref":{"id":"functions"}}')
     self.assertJson(Native.KEYS, '{"@ref":{"id":"keys"}}')
+    self.assertJson(Native.ACCESS_PROVIDERS, '{"@ref":{"id":"access_providers"}}')
 
   def test_ref(self):
     self.assertJson(Ref("collections"),
@@ -218,6 +219,15 @@ class SerializationTest(TestCase):
       query.create_role({"name": "a_role", "privileges": {"resource": query.collections(), "actions": {"read": True}}}),
       '{"create_role":{"object":{"name":"a_role","privileges":{"object":{"actions":{"object":{"read":true}},"resource":{"collections":null}}}}}}'
     )
+  
+  def test_create_access_provider(self):
+    providerName = 'provider_'
+    issuerName = 'issuer_'
+    jwksUri = 'https://auth.fauna.com/somewhere'
+    self.assertJson(
+        query.create_access_provider({"name": providerName, "issuer": issuerName, "jwks_uri": jwksUri}),
+        '{"create_access_provider":{"object":{"issuer":"'+issuerName+'","jwks_uri":"'+jwksUri+'","name":"'+providerName+'"}}}'
+    )
 
   def test_move_database(self):
     q = query.move_database(query.database("src-db"), query.database("dest-db"))
@@ -319,8 +329,20 @@ class SerializationTest(TestCase):
   def test_identity(self):
     self.assertJson(query.identity(), '{"identity":null}')
 
+  def test_current_token(self):
+    self.assertJson(query.current_token(), '{"current_token":null}')
+
+  def test_current_identity(self):
+    self.assertJson(query.current_identity(), '{"current_identity":null}')
+
   def test_has_identity(self):
     self.assertJson(query.has_identity(), '{"has_identity":null}')
+
+  def test_has_current_identity(self):
+    self.assertJson(query.has_current_identity(), '{"has_current_identity":null}')
+
+  def test_has_current_token(self):
+    self.assertJson(query.has_current_token(), '{"has_current_token":null}')
 
   #endregion
 
@@ -465,6 +487,15 @@ class SerializationTest(TestCase):
 
   def test_role(self):
     self.assertJson(query.role("role-name"), '{"role":"role-name"}')
+
+  def test_access_provider(self):
+    self.assertJson(query.access_provider("name", query.database("db1")),
+                    '{"access_provider":"name","scope":{"database":"db1"}}')
+    self.assertJson(query.access_provider("name"), '{"access_provider":"name"}')
+  
+  def test_access_providers(self):
+    self.assertJson(query.access_providers(query.database("db1")),
+                    '{"access_providers":{"database":"db1"}}')
 
   def test_equals(self):
     self.assertJson(query.equals(1), '{"equals":1}')


### PR DESCRIPTION
- Adds access_provider functions. (create_access_provider, access_provider, access_providers )
- Deprecates identity() in favor of current_identity()
- Deprecates has_identity() in favor of has_current_identity()
- Adds has_current_token() and current_token() functions 
- Added 3rdparty_auth test suite
- Bumps api_version to 4

https://faunadb.atlassian.net/browse/DRV-275