### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 3.0.0 [current]
+## 4.0.0  [current]
+- Introduce document streaming api
+- Add third party auth functions
+- Bump api_version to `4`
+- Add nightly and stable CI for Python 2.7, 3.4 and 3.8
+
+## 3.0.0
 
 - Refactored `contains` into `contains_path`, `contains_value`, `contains_path`
 - Added `reverse` function

--- a/faunadb/__init__.py
+++ b/faunadb/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "FaunaDB"
-__version__ = "3.0.0"
+__version__ = "4.0.0"
 __author__ = "Fauna, Inc"
 __license__ = "MPL 2.0"
 __copyright__ = "2020 Fauna, Inc"


### PR DESCRIPTION
- Introduce document streaming api
- Add third party auth functions
- Bump api_version to `4`
- Add nightly and stable CI for Python 2.7, 3.4 and 3.8