### PR TITLE
DRV-398 Support Bearer auth tokens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ The streaming API is blocking by default, the choice and mechanism for handling 
     def on_error(event):
         print("Received error event %s"%(event))
     options = {"fields": ["document", "diff"]}
-    stream = client.stream(doc["ref"], options, on_start, on_version, on_error)
+    stream = client.stream(doc["ref"], options, on_start, on_error, on_version)
     stream.start()
 
 Building it yourself

--- a/faunadb/streams/client.py
+++ b/faunadb/streams/client.py
@@ -7,11 +7,12 @@ except ImportError:
     #python3
     from urllib.parse import urlencode
 
-from hyper import HTTP20Connection
-from faunadb._json import to_json, parse_json_or_none
+from faunadb._json import parse_json_or_none, to_json
 from faunadb.request_result import RequestResult
-from .events import parse_stream_request_result_or_none, Error
+from hyper import HTTP20Connection
+
 from .errors import StreamError
+from .events import Error, parse_stream_request_result_or_none
 
 VALID_FIELDS = {"diff", "prev", "document", "action"}
 
@@ -63,7 +64,7 @@ class Connection(object):
         try:
             self._state = 'connecting'
             headers = self._client.session.headers
-            headers["Authorization"] = self._client._auth_header()
+            headers["Authorization"] = self._client.auth.auth_header()
             if self._client._query_timeout_ms is not None:
                     headers["X-Query-Timeout"] = str(self._client._query_timeout_ms)
             headers["X-Last-Seen-Txn"] = str(self._client.get_last_txn_time())


### PR DESCRIPTION
**Issue**
Support for `create_access_provider` and related functions has been implemented, but the lack of Bearer token support means that Python-based client applications cannot succeed in using JWT tokens in place of secrets: they always receive the error `Unauthorized`.


**Ho to test?**
follow [instruction](https://docs.fauna.com/fauna/current/security/external/auth0) to obtain an access token
```
from faunadb import query as q
from faunadb.client import FaunaClient
from faunadb.objects import Ref

client = FaunaClient(
    secret='place jwt here',
)

print(client.query(q.paginate(q.documents(q.collection('users')))))


def on_start(event):
    print("started stream at %s"%(event.txn))

def on_version(event):
    print("on_version event at %s"%(event.txn))
    print("    event: %s"%(event.event))
    stream.close()

def on_error(event):
    print("Received error event %s"%(event))
options = {"fields": ["document", "diff"]}
stream = client.stream(q.ref(q.collection('users'), '282652881944838658'), options, on_start, on_error, on_version)
stream.start()
```

For regression, re-run the same code with server secret key