### PR TITLE
feature!: always pass X-Query-Timeout

### DIFF
--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -145,6 +145,9 @@ class FaunaClient(object):
     self._query_timeout_ms = kwargs.get('query_timeout_ms')
     if self._query_timeout_ms is not None:
       self._query_timeout_ms = int(self._query_timeout_ms)
+    
+    if self._query_timeout_ms is None:
+        self._query_timeout_ms = int(timeout) * 1000
 
     if ('session' not in kwargs) or ('counter' not in kwargs):
       self.session = Session()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ class ClientTest(FaunaTestCase):
 
   def test_default_query_timeout(self):
     client = FaunaClient(secret="secret")
-    self.assertEqual(client.get_query_timeout(), 60001)
+    self.assertEqual(client.get_query_timeout(), 60000)
 
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,9 +11,14 @@ class ClientTest(FaunaTestCase):
 
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
 
+  def test_default_query_timeout(self):
+    client = FaunaClient(secret="secret")
+    self.assertEqual(client.get_query_timeout(), 60000)
+
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)
     self.assertEqual(client.get_query_timeout(), 5000)
+    
 
   def test_last_txn_time(self):
     old_time = self.client.get_last_txn_time()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ class ClientTest(FaunaTestCase):
 
   def test_default_query_timeout(self):
     client = FaunaClient(secret="secret")
-    self.assertEqual(client.get_query_timeout(), 60000)
+    self.assertEqual(client.get_query_timeout(), 60001)
 
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)


### PR DESCRIPTION
### Notes
We should make sure that the `x-query-timeout` header is always sent to the server with either the user-defined query timeout, or with the client-side request timeout.

### Jira ticket
[DRV-522](https://faunadb.atlassian.net/browse/DRV-522)