### PR TITLE
DRV-525 select with default

### DIFF
--- a/faunadb/query.py
+++ b/faunadb/query.py
@@ -799,10 +799,13 @@ def contains_value(value, in_):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/containsvalue>`__."""
   return _fn({"contains_value": value, "in": in_})
 
-def select(path, from_):
+def select(path, from_, default=None):
   """
   See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/select>`__.
   See also :py:func:`select_with_default`."""
+  if default is not None:
+    return select_with_default(path, from_, default)
+
   return _fn({"select": path, "from": from_})
 
 

--- a/faunadb/query.py
+++ b/faunadb/query.py
@@ -803,12 +803,13 @@ def select(path, from_, default=None):
   """
   See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/select>`__.
   See also :py:func:`select_with_default`."""
+  _dict = {"select": path, "from": from_}
   if default is not None:
-    return select_with_default(path, from_, default)
+    _dict["default"] = default
+  return _fn(_dict)
 
-  return _fn({"select": path, "from": from_})
 
-
+@deprecated("Use `select` instead")
 def select_with_default(path, from_, default):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/select>`__."""
   return _fn({"select": path, "from": from_, "default": default})

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -444,34 +444,34 @@ class QueryTest(FaunaTestCase):
     self.assertEqual(self._q(q3), {"a": 5, "b": 2, "c": 3})
     self.assertEqual(self._q(q4), {"a": 'a', "b": 'b', "c": 'c'})
 
-  def test_reverse(self):
-    #arrays
-    list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    self.assertEqual(self._q(query.reverse(list)), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
-    self.assertEqual(self._q(query.reverse(query.reverse(list))), list)
-    self.assertEqual(self._q(query.reverse([])), [])
+  # def test_reverse(self):
+  #   #arrays
+  #   list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  #   self.assertEqual(self._q(query.reverse(list)), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
+  #   self.assertEqual(self._q(query.reverse(query.reverse(list))), list)
+  #   self.assertEqual(self._q(query.reverse([])), [])
 
-    self._q(query.create_collection({"name": "reverse_collection"}))
-    self._q(query.create_index({
-      "name": "rev_coll_idx",
-      "source": query.collection("reverse_collection"),
-      "values": [{"field": ["data", "val"]}]
-    }))
-    index = query.index("rev_coll_idx")
-    for i in range(100):
-      self._q(query.create(query.collection(
-          "reverse_collection"), {"data": {"val": i}}))
-    assertPaginate = lambda q, expected, size = None : self.assertEqual(self._q(query.select("data", query.paginate(q, size))), expected)
+  #   self._q(query.create_collection({"name": "reverse_collection"}))
+  #   self._q(query.create_index({
+  #     "name": "rev_coll_idx",
+  #     "source": query.collection("reverse_collection"),
+  #     "values": [{"field": ["data", "val"]}]
+  #   }))
+  #   index = query.index("rev_coll_idx")
+  #   for i in range(100):
+  #     self._q(query.create(query.collection(
+  #         "reverse_collection"), {"data": {"val": i}}))
+  #   assertPaginate = lambda q, expected, size = None : self.assertEqual(self._q(query.select("data", query.paginate(q, size))), expected)
 
-    assertPaginate(query.reverse(query.match(index)), [99, 98, 97, 96, 95], 5)
-    assertPaginate(query.reverse(query.reverse(query.match(index))), list, 11)
+  #   assertPaginate(query.reverse(query.match(index)), [99, 98, 97, 96, 95], 5)
+  #   assertPaginate(query.reverse(query.reverse(query.match(index))), list, 11)
 
-    q1 = query.select(["data", 0], query.reverse(query.paginate(query.match(index), size=50)))
-    self.assertEqual(self._q(q1), 49)
+  #   q1 = query.select(["data", 0], query.reverse(query.paginate(query.match(index), size=50)))
+  #   self.assertEqual(self._q(q1), 49)
 
-    self._assert_bad_query(query.reverse("a string"))
-    self._assert_bad_query(query.reverse(index))
-    self._assert_bad_query(query.reverse({"a": 1, "b": 2}))
+  #   self._assert_bad_query(query.reverse("a string"))
+  #   self._assert_bad_query(query.reverse(index))
+  #   self._assert_bad_query(query.reverse({"a": 1, "b": 2}))
 
   def test_intersection(self):
     n_value = 102
@@ -837,6 +837,7 @@ class QueryTest(FaunaTestCase):
     obj = {"a": {"b": 1}}
     self.assertEqual(self._q(query.select("a", obj)), {"b": 1})
     self.assertEqual(self._q(query.select(["a", "b"], obj)), 1)
+    self.assertEqual(self._q(query.select(["a", "c"], obj, 'default')), 'default')
     self.assertIsNone(self._q(query.select_with_default("c", obj, None)))
     self.assertRaises(NotFound, lambda: self._q(query.select("c", obj)))
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -444,34 +444,34 @@ class QueryTest(FaunaTestCase):
     self.assertEqual(self._q(q3), {"a": 5, "b": 2, "c": 3})
     self.assertEqual(self._q(q4), {"a": 'a', "b": 'b', "c": 'c'})
 
-  # def test_reverse(self):
-  #   #arrays
-  #   list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-  #   self.assertEqual(self._q(query.reverse(list)), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
-  #   self.assertEqual(self._q(query.reverse(query.reverse(list))), list)
-  #   self.assertEqual(self._q(query.reverse([])), [])
+  def test_reverse(self):
+    #arrays
+    list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    self.assertEqual(self._q(query.reverse(list)), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
+    self.assertEqual(self._q(query.reverse(query.reverse(list))), list)
+    self.assertEqual(self._q(query.reverse([])), [])
 
-  #   self._q(query.create_collection({"name": "reverse_collection"}))
-  #   self._q(query.create_index({
-  #     "name": "rev_coll_idx",
-  #     "source": query.collection("reverse_collection"),
-  #     "values": [{"field": ["data", "val"]}]
-  #   }))
-  #   index = query.index("rev_coll_idx")
-  #   for i in range(100):
-  #     self._q(query.create(query.collection(
-  #         "reverse_collection"), {"data": {"val": i}}))
-  #   assertPaginate = lambda q, expected, size = None : self.assertEqual(self._q(query.select("data", query.paginate(q, size))), expected)
+    self._q(query.create_collection({"name": "reverse_collection"}))
+    self._q(query.create_index({
+      "name": "rev_coll_idx",
+      "source": query.collection("reverse_collection"),
+      "values": [{"field": ["data", "val"]}]
+    }))
+    index = query.index("rev_coll_idx")
+    for i in range(100):
+      self._q(query.create(query.collection(
+          "reverse_collection"), {"data": {"val": i}}))
+    assertPaginate = lambda q, expected, size = None : self.assertEqual(self._q(query.select("data", query.paginate(q, size))), expected)
 
-  #   assertPaginate(query.reverse(query.match(index)), [99, 98, 97, 96, 95], 5)
-  #   assertPaginate(query.reverse(query.reverse(query.match(index))), list, 11)
+    assertPaginate(query.reverse(query.match(index)), [99, 98, 97, 96, 95], 5)
+    assertPaginate(query.reverse(query.reverse(query.match(index))), list, 11)
 
-  #   q1 = query.select(["data", 0], query.reverse(query.paginate(query.match(index), size=50)))
-  #   self.assertEqual(self._q(q1), 49)
+    q1 = query.select(["data", 0], query.reverse(query.paginate(query.match(index), size=50)))
+    self.assertEqual(self._q(q1), 49)
 
-  #   self._assert_bad_query(query.reverse("a string"))
-  #   self._assert_bad_query(query.reverse(index))
-  #   self._assert_bad_query(query.reverse({"a": 1, "b": 2}))
+    self._assert_bad_query(query.reverse("a string"))
+    self._assert_bad_query(query.reverse(index))
+    self._assert_bad_query(query.reverse({"a": 1, "b": 2}))
 
   def test_intersection(self):
     n_value = 102


### PR DESCRIPTION
### Notes 
In the python driver, Select() does not accept the 3rd default parameter.
It would be better if we didn't have to use select_with_default() - as this isn't very intuitive and not according to the Docs.

### Jira ticket
[DRV-525](https://faunadb.atlassian.net/browse/DRV-525)