### PR TITLE
fix(OSS-578): expose whole error

### DIFF
--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -106,7 +106,7 @@ class FaunaClient(object):
       domain="db.fauna.com",
       scheme="https",
       port=None,
-      query_timeout_ms=60 * 1000,
+      timeout=60,
       observer=None,
       pool_connections=10,
       pool_maxsize=10,
@@ -120,8 +120,8 @@ class FaunaClient(object):
       ``"http"`` or ``"https"``.
     :param port:
       Port of the FaunaDB server.
-    :param query_timeout_ms:
-      Read query_timeout_ms in milliseconds.
+    :param timeout:
+      Read timeout in seconds.
     :param observer:
       Callback that will be passed a :any:`RequestResult` after every completed request.
     :param pool_connections:
@@ -142,7 +142,7 @@ class FaunaClient(object):
     self.pool_maxsize = pool_maxsize
 
     self._last_txn_time = kwargs.get('last_txn_time') or _LastTxnTime()
-    self._query_timeout_ms = query_timeout_ms
+    self._query_timeout_ms = kwargs.get('query_timeout_ms')
     if self._query_timeout_ms is not None:
       self._query_timeout_ms = int(self._query_timeout_ms)
 
@@ -162,7 +162,7 @@ class FaunaClient(object):
       })
       if self._query_timeout_ms is not None:
         self.session.headers["X-Query-Timeout"] = str(self._query_timeout_ms)
-      self.session.timeout = self._query_timeout_ms
+      self.session.timeout = timeout
     else:
       self.session = kwargs['session']
       self.counter = kwargs['counter']

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -253,6 +253,7 @@ class FaunaClient(object):
                          domain=self.domain,
                          scheme=self.scheme,
                          port=self.port,
+                         timeout=self.session.timeout,
                          observer=observer or self.observer,
                          session=self.session,
                          counter=self.counter,

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -145,6 +145,9 @@ class FaunaClient(object):
     self._query_timeout_ms = kwargs.get('query_timeout_ms')
     if self._query_timeout_ms is not None:
       self._query_timeout_ms = int(self._query_timeout_ms)
+    
+    if self._query_timeout_ms is None:
+        self._query_timeout_ms = int(timeout) * 1000
 
     if ('session' not in kwargs) or ('counter' not in kwargs):
       self.session = Session()

--- a/faunadb/errors.py
+++ b/faunadb/errors.py
@@ -62,6 +62,9 @@ class HttpError(FaunaError):
     errors = _get_or_raise(request_result, response, "errors")
     return [ErrorData.from_dict(error, request_result) for error in errors]
 
+  def __str__(self) -> str:
+      return repr(self.errors[0])
+
   def _get_description(self):
     return self.errors[0].description if self.errors else "(empty `errors`)"
 

--- a/faunadb/errors.py
+++ b/faunadb/errors.py
@@ -62,7 +62,7 @@ class HttpError(FaunaError):
     errors = _get_or_raise(request_result, response, "errors")
     return [ErrorData.from_dict(error, request_result) for error in errors]
 
-  def __str__(self) -> str:
+  def __str__(self):
       return repr(self.errors[0])
 
   def _get_description(self):

--- a/faunadb/errors.py
+++ b/faunadb/errors.py
@@ -134,7 +134,7 @@ class ErrorData(object):
     """
 
   def __repr__(self):
-    return "ErrorData(%s, %s, %s, %s)" % \
+    return "ErrorData(code=%s, description=%s, position=%s, failures=%s)" % \
            (repr(self.code), repr(self.description), repr(self.position), repr(self.failures))
 
   def __eq__(self, other):
@@ -169,7 +169,7 @@ class Failure(object):
     """Field of the failure in the instance."""
 
   def __repr__(self):
-    return "Failure(%s, %s, %s)" % (repr(self.code), repr(self.description), repr(self.field))
+    return "Failure(code=%s, description=%s, field=%s)" % (repr(self.code), repr(self.description), repr(self.field))
 
   def __eq__(self, other):
     return self.code == other.code and \

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ class ClientTest(FaunaTestCase):
 
   def test_default_query_timeout(self):
     client = FaunaClient(secret="secret")
-    self.assertEqual(client.get_query_timeout(), 60001)
+    self.assertEqual(client.get_query_timeout(), 60000)
 
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,9 +11,14 @@ class ClientTest(FaunaTestCase):
 
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
 
+  def test_default_query_timeout(self):
+    client = FaunaClient(secret="secret")
+    self.assertEqual(client.get_query_timeout(), 60000)
+
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)
     self.assertEqual(client.get_query_timeout(), 5000)
+    
 
   def test_last_txn_time(self):
     old_time = self.client.get_last_txn_time()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,10 +11,6 @@ class ClientTest(FaunaTestCase):
 
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
 
-  def test_default_query_timeout(self):
-    client = FaunaClient(secret="secret")
-    self.assertEqual(client.get_query_timeout(), 60000)
-
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)
     self.assertEqual(client.get_query_timeout(), 5000)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ class ClientTest(FaunaTestCase):
 
   def test_default_query_timeout(self):
     client = FaunaClient(secret="secret")
-    self.assertEqual(client.get_query_timeout(), 60000)
+    self.assertEqual(client.get_query_timeout(), 60001)
 
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -121,13 +121,13 @@ class ErrorsTest(FaunaTestCase):
 
   def test_repr(self):
     err = ErrorData("code", "desc", None, None)
-    self.assertEqual(repr(err), "ErrorData('code', 'desc', None, None)")
+    self.assertEqual(repr(err), "ErrorData(code='code', description='desc', position=None, failures=None)")
 
     failure = Failure("code", "desc", ["a", "b"])
     err = ErrorData("code", "desc", ["pos"], [failure])
     self.assertEqual(
       repr(err),
-      "ErrorData('code', 'desc', ['pos'], [Failure('code', 'desc', ['a', 'b'])])")
+      "ErrorData(code='code', description='desc', position=['pos'], failures=[Failure(code='code', description='desc', field=['a', 'b'])])")
 
   #region private
 


### PR DESCRIPTION
[Shallow ValidationError - Expose "failures" object](https://faunadb.atlassian.net/browse/OSS-578)

If you create a collection or index, immediately delete it, and then try creating either, it throws a BadRequest saying document data is invalid without details of the real error cause.

```python
from faunadb import query as q
from faunadb.client import FaunaClient

client = FaunaClient(secret="")

client.query(q.create_collection({"name": "test"}))
client.query(q.delete(q.collection('test')))
client.query(q.create_collection({"name": "test"}))

```

before
```
faunadb.errors.BadRequest: document data is not valid.
```
after
```
faunadb.errors.BadRequest: ErrorData(code='validation failed', description='document data is not valid.', position=['create_collection'], failures=[Failure(code='duplicate value', description='Value is cached. Please wait at least 60 seconds after creating or renaming a collection or index before reusing its name.', field=['name'])])
```