### PR TITLE
Allow None as value to select's default parameter

### DIFF
--- a/faunadb/query.py
+++ b/faunadb/query.py
@@ -799,12 +799,14 @@ def contains_value(value, in_):
   """See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/containsvalue>`__."""
   return _fn({"contains_value": value, "in": in_})
 
-def select(path, from_, default=None):
+_NO_DEFAULT = object()
+
+def select(path, from_, default=_NO_DEFAULT):
   """
   See the `docs <https://docs.fauna.com/fauna/current/api/fql/functions/select>`__.
   See also :py:func:`select_with_default`."""
   _dict = {"select": path, "from": from_}
-  if default is not None:
+  if default is not _NO_DEFAULT:
     _dict["default"] = default
   return _fn(_dict)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -839,6 +839,7 @@ class QueryTest(FaunaTestCase):
     self.assertEqual(self._q(query.select(["a", "b"], obj)), 1)
     self.assertEqual(self._q(query.select(["a", "c"], obj, 'default')), 'default')
     self.assertIsNone(self._q(query.select_with_default("c", obj, None)))
+    self.assertIsNone(self._q(query.select("c", obj, default=None)))
     self.assertRaises(NotFound, lambda: self._q(query.select("c", obj)))
 
   def test_select_all(self):


### PR DESCRIPTION
Implement the [sentinel object pattern](https://python-patterns.guide/python/sentinel-object/#sentinel-objects) to distinguish explicit passing of `None` for `default`

Fixes #191