### PR TITLE
chore(FE-1639): Changed reference to a docs for particular version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ The following versions of Python are supported:
 Documentation
 -------------
 
-Driver documentation is available at https://fauna.github.io/faunadb-python/.
+Driver documentation is available at https://fauna.github.io/faunadb-python/4.1.1/api/.
 
 See the `FaunaDB Documentation <https://docs.fauna.com/>`_ for a complete API reference, or look in `tests`_
 for more examples.


### PR DESCRIPTION
### Notes
Concourse CI creates a separate folder in the `gh-pages` for a specific version, this PR adds a reference to the latest `v4` version of the driver into the readme file.