### PR TITLE
Test fix: Use "core" Fauna Dev Docker image instead of "enterprise" (v5)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     docker:
       - image: circleci/python:<<parameters.python_version>>
 
-      - image: gcr.io/faunadb-cloud/faunadb/enterprise:latest
+      - image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
         name: core
         auth:
           username: _json_key


### PR DESCRIPTION
The Python driver currently uses the out-of-date "enterprise" flavor of the Fauna Dev Docker image; this change migrates to using the "core" flavor instead.

The CircleCI workflow will test this change with existing test automation.