### PR TITLE
Test fix: Use "core" Fauna Dev Docker image instead of "enterprise" (v4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     docker:
       - image: circleci/python:<<parameters.python_version>>
 
-      - image: gcr.io/faunadb-cloud/faunadb/enterprise/<<parameters.version>>:latest
+      - image: gcr.io/faunadb-cloud/faunadb/core/<<parameters.version>>:latest
         name: core
         auth:
           username: _json_key


### PR DESCRIPTION
This is a modified cherry-pick of https://github.com/fauna/faunadb-python/pull/222.

The CircleCI workflow will test this change via existing test automation.