### PR TITLE
[FE-2591] add client endpoint param

### DIFF
--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -175,6 +175,7 @@ class FaunaClient(object):
             observer=None,
             pool_connections=10,
             pool_maxsize=10,
+            endpoint=None,
             **kwargs):
         """
         :param secret:
@@ -193,6 +194,8 @@ class FaunaClient(object):
           The number of connection pools to cache.
         :param pool_maxsize:
           The maximum number of connections to save in the pool.
+        :param endpoint:
+          Full URL for the FaunaDB server.
         """
 
         self.check_new_version()
@@ -203,7 +206,7 @@ class FaunaClient(object):
                      "https" else 80) if port is None else port
 
         self.auth = HTTPBearerAuth(secret)
-        self.base_url = "%s://%s:%s" % (self.scheme, self.domain, self.port)
+        self.base_url = endpoint if endpoint else "%s://%s:%s" % (self.scheme, self.domain, self.port)
         self.observer = observer
 
         self.pool_connections = pool_connections

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -88,6 +88,19 @@ class FaunaTestCase(TestCase):
     non_null_args = {k: v for k, v in args.items() if v is not None}
     return FaunaClient(secret=_FAUNA_ROOT_KEY, **non_null_args)
 
+  @classmethod
+  def _get_client_from_endpoint(cls):
+    args = {
+      "endpoint": "%s://%s:%s" % (_FAUNA_SCHEME, _FAUNA_DOMAIN, _FAUNA_PORT),
+      "domain": "bad domain",
+      "scheme": "bad scheme",
+      "port": "bad port",
+      "query_timeout_ms": _FAUNA_QUERY_TIMEOUT_MS
+    }
+    # If None, use default instead
+    non_null_args = {k: v for k, v in args.items() if v is not None}
+    return FaunaClient(secret=_FAUNA_ROOT_KEY, **non_null_args)
+
   def assert_raises(self, exception_class, action):
     """Like self.assertRaises and returns the exception too."""
     with self.assertRaises(exception_class) as cm:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,14 @@ class ClientTest(FaunaTestCase):
 
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
 
+  def test_ping_using_endpoint(self):
+    client = self._get_client_from_endpoint()
+    old_time = client.get_last_txn_time()
+    self.assertEqual(client.ping("node"), "Scope node is OK")
+    new_time = client.get_last_txn_time()
+
+    self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
+
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)
     self.assertEqual(client.get_query_timeout(), 5000)


### PR DESCRIPTION
### Notes
[Jira](https://faunadb.atlassian.net/browse/FE-2591)

The endpoint parameter is supported by other drivers.  Implement it for the Python driver.

Those drivers that support endpoint do not support the scheme + domain + port parameters, so we need to determine how to handle the case where endpoint and the others are included.  My suggestion is that if endpoint is set, then the other three are ignored, and that is what this PR does.

### Use cases

- The `/linearized` endpoint is not currently useable with the python driver.  Or at least not reasonably.  You can specify the port as `443/linearized` to make it work, but it is not reasonable to advise folks to do  this.
- arbitrary endpoints are not currently possible.  For example if you want to send requests through a proxy.  Again, you can most likely work around this by hacking the `port` parameter.

### How to test
A test was added.  No changes in environment or configuration are required to run the test.
