### PR TITLE
Bump to 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-## 4.2.0 [current]
+## 4.3.0 [current]
+- Add optional endpoint parameter as an alternative to setting scheme, domain and port individually. The new parameter
+  will override scheme, domain and port if set. [#240](https://github.com/fauna/faunadb-python/pull/240)
+
+## 4.2.0
 - Add support for [set streaming](https://docs.fauna.com/fauna/current/drivers/streaming). Pull request for set streaming [here](https://github.com/fauna/faunadb-python/pull/221).
 
 ## 4.1.1
 - Exposes all the fields in the `errors` object
-- Allows setting select function's default parameter as None value 
+- Allows setting select function's default parameter as None value
 - Notifies about new package version
 
 ## 4.1.0

--- a/faunadb/__init__.py
+++ b/faunadb/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "FaunaDB"
-__version__ = "4.2.0"
+__version__ = "4.3.0"
 __api_version__ = "4"
 __author__ = "Fauna, Inc"
 __license__ = "MPL 2.0"


### PR DESCRIPTION
Bump version to 4.3.0 and update changelog.

Here is the [full diff](https://github.com/fauna/faunadb-python/compare/42a955a0236bb8b0cb397a16c0a950cca0d844b5..6a90b6efbe6257ddc892f1855b39a06bca3d79dc) between `4.2.0` and this release, although the only PR to change functionality is [#240](https://github.com/fauna/faunadb-python/pull/240).