### PR TITLE
Allow endpoint param to contain trailing slashes

### DIFF
--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -206,7 +206,8 @@ class FaunaClient(object):
                      "https" else 80) if port is None else port
 
         self.auth = HTTPBearerAuth(secret)
-        self.base_url = endpoint.strip("/\\") if endpoint else "%s://%s:%s" % (self.scheme, self.domain, self.port)
+        constructed_url = "%s://%s:%s" % (self.scheme, self.domain, self.port)
+        self.base_url = self._normalize_endpoint(endpoint) if endpoint else constructed_url
         self.observer = observer
 
         self.pool_connections = pool_connections
@@ -280,6 +281,9 @@ class FaunaClient(object):
         Get the query timeout for all queries.
         """
         return self._query_timeout_ms
+
+    def _normalize_endpoint(self, endpoint):
+      return endpoint.rstrip("/\\")
 
     def __del__(self):
         if self.counter.decrement() == 0:

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -206,7 +206,7 @@ class FaunaClient(object):
                      "https" else 80) if port is None else port
 
         self.auth = HTTPBearerAuth(secret)
-        self.base_url = endpoint if endpoint else "%s://%s:%s" % (self.scheme, self.domain, self.port)
+        self.base_url = endpoint.strip("/\\") if endpoint else "%s://%s:%s" % (self.scheme, self.domain, self.port)
         self.observer = observer
 
         self.pool_connections = pool_connections

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -89,9 +89,13 @@ class FaunaTestCase(TestCase):
     return FaunaClient(secret=_FAUNA_ROOT_KEY, **non_null_args)
 
   @classmethod
+  def _get_fauna_endpoint(cls):
+    return "%s://%s:%s" % (_FAUNA_SCHEME, _FAUNA_DOMAIN, _FAUNA_PORT)
+
+  @classmethod
   def _get_client_from_endpoint(cls):
     args = {
-      "endpoint": "%s://%s:%s" % (_FAUNA_SCHEME, _FAUNA_DOMAIN, _FAUNA_PORT),
+      "endpoint": cls._get_fauna_endpoint(),
       "domain": "bad domain",
       "scheme": "bad scheme",
       "port": "bad port",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,9 +21,9 @@ class ClientTest(FaunaTestCase):
     new_time = client.get_last_txn_time()
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
 
-    # test endpoints with trailing slashes etc
+  def test_endpoint_normalization(self):
     endpoint = self._get_fauna_endpoint()
-    endpoints = [endpoint + "/", endpoint + "//", endpoint + "\\", endpoint + "\\\\"]
+    endpoints = [endpoint, endpoint + "/", endpoint + "//", endpoint + "\\", endpoint + "\\\\"]
     for e in endpoints:
       client = FaunaClient(secret="secret", endpoint=e)
       self.assertEqual(client.ping("node"), "Scope node is OK")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -80,8 +80,3 @@ class ClientTest(FaunaTestCase):
     )
 
     os.environ["PATH"] = originalPath
-
-  def test_client_constructor(self):
-    client = FaunaClient(secret="secret", )
-
-

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,6 @@ class ClientTest(FaunaTestCase):
     old_time = self.client.get_last_txn_time()
     self.assertEqual(self.client.ping("node"), "Scope node is OK")
     new_time = self.client.get_last_txn_time()
-
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
 
   def test_ping_using_endpoint(self):
@@ -20,19 +19,23 @@ class ClientTest(FaunaTestCase):
     old_time = client.get_last_txn_time()
     self.assertEqual(client.ping("node"), "Scope node is OK")
     new_time = client.get_last_txn_time()
-
     self.assertEqual(old_time, new_time) # client.ping should not update last-txn-time
+
+    # test endpoints with trailing slashes etc
+    endpoint = self._get_fauna_endpoint()
+    endpoints = [endpoint + "/", endpoint + "//", endpoint + "\\", endpoint + "\\\\"]
+    for e in endpoints:
+      client = FaunaClient(secret="secret", endpoint=e)
+      self.assertEqual(client.ping("node"), "Scope node is OK")
 
   def test_query_timeout(self):
     client = FaunaClient(secret="secret", query_timeout_ms=5000)
     self.assertEqual(client.get_query_timeout(), 5000)
-    
 
   def test_last_txn_time(self):
     old_time = self.client.get_last_txn_time()
     self.client.query({})
     new_time = self.client.get_last_txn_time()
-
     self.assertTrue(old_time < new_time) # client.query should update last-txn-time
 
   def test_last_txn_time_upated(self):
@@ -77,5 +80,8 @@ class ClientTest(FaunaTestCase):
     )
 
     os.environ["PATH"] = originalPath
+
+  def test_client_constructor(self):
+    client = FaunaClient(secret="secret", )
 
 


### PR DESCRIPTION
## Problem
The new endpoint param introduced in [#240](https://github.com/fauna/faunadb-python/pull/240) will not work if it contains a trailing slash (`https://db.fauna.com/` for example).

## Solution
Strip trailing slashes from the endpoint if it is not `None`.

## Testing
Test ping on clients created using endpoint parameters with trailing slashes.