### PR TITLE
Update python docker image

### DIFF
--- a/concourse/tasks/build.yml
+++ b/concourse/tasks/build.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: python
-    tag: 3.9.5-alpine3.13
+    tag: 3.9.14-alpine3.16
 
 inputs:
   - name: fauna-python-repository


### PR DESCRIPTION
Update the python docker image used by the  `build` step to `3.9.14-alpine3.16` which ships with a newer version of `pip` as suggested [here](https://cryptography.io/en/latest/faq/#installing-cryptography-fails-with-error-can-not-find-rust-compiler). 

TLDR it seems rust is required to build one of our dependencies (cryptography) which is causing the build to fail but newer versions of pip ship with the dependency pre compiled.