### PR TITLE
Fix README formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Documentation
 
 Driver documentation is available at https://fauna.github.io/faunadb-python/4.1.1/api/.
 
-See the `FaunaDB Documentation <https://docs.fauna.com/>`_ for a complete API reference, or look in `tests`_
+See the `FaunaDB Documentation <https://docs.fauna.com/>`_ for a complete API reference, or look in `tests`__
 for more examples.
 
 
@@ -94,7 +94,7 @@ Observing Metrics
 
 Its possible to observe each query's metrics by providing an "observer" callback.
 
-More information on query metrics is available in the `FaunaDB Documentation <https://docs.fauna.com/fauna/current/learn/understanding/billing#perquery>`_.
+More information on query metrics is available in the `FaunaDB Documentation <https://docs.fauna.com/fauna/current/learn/understanding/billing#perquery>`__.
 
 Here is a simple example:
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Documentation
 
 Driver documentation is available at https://fauna.github.io/faunadb-python/4.1.1/api/.
 
-See the `FaunaDB Documentation <https://docs.fauna.com/>`_ for a complete API reference, or look in `tests`__
+See the `FaunaDB Documentation <https://docs.fauna.com/>`__ for a complete API reference, or look in `tests`_
 for more examples.
 
 


### PR DESCRIPTION
The README had a duplicate link name `FaunaDB Documentation` which needs to be formatted with `__` instead of `_` to indicate it is an anonymous reference. See https://github.com/sphinx-doc/sphinx/issues/3921 for details.

Tested fix with https://github.com/rstcheck/rstcheck.