### PR TITLE
[FE-2401] create new job for testing the staging branch, add slack notification to code

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -7,6 +7,13 @@ resources:
       uri: https://github.com/fauna/faunadb-python
       branch: v4
 
+  - name: fauna-python-repository-staging
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/fauna/faunadb-python
+      branch: v4-staging
+
   - name: fauna-python-repository-docs
     type: git
     icon: github
@@ -14,6 +21,26 @@ resources:
       uri: git@github.com:fauna/faunadb-python.git
       branch: gh-pages
       private_key: ((github_repo_key))
+
+  - name: notify
+    type: slack-notification
+    source:
+      url: ((slack-webhook))
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+groups:
+  - name: standard-release
+    jobs:
+      - release
+  - name: staging-tests
+    jobs:
+      - run-staging-tests
 
 jobs:
   - name: release
@@ -37,6 +64,10 @@ jobs:
 
       - task: publish
         file: fauna-python-repository/concourse/tasks/publish.yml
+        on_success:
+          params:
+            text_file: slack-message/publish
+          put: notify
         params:
           TWINE_USERNAME: ((pypi-username))
           TWINE_PASSWORD: ((pypi-password))
@@ -47,3 +78,17 @@ jobs:
       - put: fauna-python-repository-docs
         params:
           repository: fauna-python-repository-updated-docs
+  - name: run-staging-tests
+    serial: true
+    public: false
+    plan:
+      - get: fauna-python-repository-staging
+
+      - task: integration-tests
+        file: fauna-python-repository-staging/concourse/tasks/integration-tests.yml
+        privileged: true
+        params:
+          FAUNA_ROOT_KEY: ((fauna.secret))
+          FAUNA_DOMAIN: ((fauna.domain))
+          FAUNA_SCHEME: ((fauna.scheme))
+          FAUNA_PORT: ((fauna.port))


### PR DESCRIPTION
Created a new concourse group. Pending changes for v4 can be pushed into v4-staging and run the integ tests against them there. Looks like we had a slack notifier on the pipeline as well but it wasn't mastered in code. Added that in as well.

Concourse diff:
```
➜  faunadb-python git:(v4-staging) ✗ fly -t devex set-pipeline --pipeline python-driver-release-v4 --config concourse/pipeline.yml
groups:
  group standard-release has been added:
+ jobs:
+ - release
+ name: standard-release

  group staging-tests has been added:
+ jobs:
+ - run-staging-tests
+ name: staging-tests

resources:
  resource fauna-python-repository-staging has been added:
+ icon: github
+ name: fauna-python-repository-staging
+ source:
+   branch: v4-staging
+   uri: https://github.com/fauna/faunadb-python
+ type: git

resource types:
  resource type slack-notification has changed:
  name: slack-notification
  source:
    repository: cfcommunity/slack-notification-resource
+   tag: latest
  type: docker-image

jobs:
  job run-staging-tests has been added:
+ name: run-staging-tests
+ plan:
+ - get: fauna-python-repository-staging
+ - file: fauna-python-repository-staging/concourse/tasks/integration-tests.yml
+   params:
+     FAUNA_DOMAIN: ((fauna.domain))
+     FAUNA_PORT: ((fauna.port))
+     FAUNA_ROOT_KEY: ((fauna.secret))
+     FAUNA_SCHEME: ((fauna.scheme))
+   privileged: true
+   task: integration-tests
+ serial: true

pipeline name: python-driver-release-v4

apply configuration? [yN]:
```