### PR TITLE
Add "x-fauna-tags" and "traceparent" headers on queries to Fauna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 4.3.1 [current]
+## 4.4.0 [current]
+- Add `tags` and `traceparent` headers. [#256](https://github.com/fauna/faunadb-python/pull/256)
+
+## 4.3.1
 - Fix the X-Last-Seen-Txn header. [#250](https://github.com/fauna/faunadb-python/pull/250)
 - Fix the changelog link emitted from upgrade prompt. [#249])(https://github.com/fauna/faunadb-python/pull/249)
 

--- a/faunadb/__init__.py
+++ b/faunadb/__init__.py
@@ -1,6 +1,6 @@
 __title__ = "FaunaDB"
-__version__ = "4.3.1"
+__version__ = "4.4.0"
 __api_version__ = "4"
 __author__ = "Fauna, Inc"
 __license__ = "MPL 2.0"
-__copyright__ = "2020 Fauna, Inc"
+__copyright__ = "2023 Fauna, Inc"

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -419,10 +419,10 @@ class FaunaClient(object):
         if len(tags_dict) > 25:
             raise Exception("Tags header only supports up to 25 key-value pairs")
 
-        if any([len(k) > 40 or not re.match("^\w+$", k) for k in tags_dict]):
+        if any([not bool(re.match("^\w{1,40}$", k)) for k in tags_dict]):
             raise Exception("One or more tag keys are invalid; keys can be up to 40 characters long and can only include letters, numbers, and '_'")
 
-        if any([len(v) > 80 or not re.match("^\w+$", v) for v in tags_dict.values()]):
+        if any([not bool(re.match("^\w{1,80}$", v)) for v in tags_dict.values()]):
             raise Exception("One or more tag values are invalid; values can be up to 80 characters long and can only include letters, numbers, and '_'")
         
         return ",".join(["=".join([k, tags_dict[k]]) for k in tags_dict])

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -414,7 +414,7 @@ class FaunaClient(object):
 
     def _get_tags_string(self, tags_dict):
         if not isinstance(tags_dict, dict):
-            raise Exception("Tags must be an object of type dict")
+            raise Exception("Tags must be a dictionary")
 
         if len(tags_dict) > 25:
             raise Exception("Tags header only supports up to 25 key-value pairs")

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -419,16 +419,16 @@ class FaunaClient(object):
         if len(tags_dict) > 25:
             raise Exception("Tags header only supports up to 25 key-value pairs")
 
-        if any([not bool(re.match("^\w{1,40}$", k)) for k in tags_dict]):
+        if any([not bool(re.match("\A\w{1,40}\z", k)) for k in tags_dict]):
             raise Exception("One or more tag keys are invalid; keys can be up to 40 characters long and can only include letters, numbers, and '_'")
 
-        if any([not bool(re.match("^\w{1,80}$", v)) for v in tags_dict.values()]):
+        if any([not bool(re.match("\A\w{1,80}\z", v)) for v in tags_dict.values()]):
             raise Exception("One or more tag values are invalid; values can be up to 80 characters long and can only include letters, numbers, and '_'")
         
         return ",".join(["=".join([k, tags_dict[k]]) for k in tags_dict])
 
     def _is_valid_traceparent(self, traceparent):
-        if not bool(re.match("^[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}$", traceparent)):
+        if not bool(re.match("\A[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}\z", traceparent)):
             raise Exception("Traceparent format is incorrect")
 
         return True

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -419,16 +419,16 @@ class FaunaClient(object):
         if len(tags_dict) > 25:
             raise Exception("Tags header only supports up to 25 key-value pairs")
 
-        if any([not bool(re.match("\A\w{1,40}\z", k)) for k in tags_dict]):
+        if any([not bool(re.match("^\w{1,40}$", k)) for k in tags_dict]):
             raise Exception("One or more tag keys are invalid; keys can be up to 40 characters long and can only include letters, numbers, and '_'")
 
-        if any([not bool(re.match("\A\w{1,80}\z", v)) for v in tags_dict.values()]):
+        if any([not bool(re.match("^\w{1,80}$", v)) for v in tags_dict.values()]):
             raise Exception("One or more tag values are invalid; values can be up to 80 characters long and can only include letters, numbers, and '_'")
         
         return ",".join(["=".join([k, tags_dict[k]]) for k in tags_dict])
 
     def _is_valid_traceparent(self, traceparent):
-        if not bool(re.match("\A[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}\z", traceparent)):
+        if not bool(re.match("^[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}$", traceparent)):
             raise Exception("Traceparent format is incorrect")
 
         return True

--- a/faunadb/client.py
+++ b/faunadb/client.py
@@ -415,20 +415,8 @@ class FaunaClient(object):
     def _get_tags_string(self, tags_dict):
         if not isinstance(tags_dict, dict):
             raise Exception("Tags must be a dictionary")
-
-        if len(tags_dict) > 25:
-            raise Exception("Tags header only supports up to 25 key-value pairs")
-
-        if any([not bool(re.match("^\w{1,40}$", k)) for k in tags_dict]):
-            raise Exception("One or more tag keys are invalid; keys can be up to 40 characters long and can only include letters, numbers, and '_'")
-
-        if any([not bool(re.match("^\w{1,80}$", v)) for v in tags_dict.values()]):
-            raise Exception("One or more tag values are invalid; values can be up to 80 characters long and can only include letters, numbers, and '_'")
         
         return ",".join(["=".join([k, tags_dict[k]]) for k in tags_dict])
 
     def _is_valid_traceparent(self, traceparent):
-        if not bool(re.match("^[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}$", traceparent)):
-            raise Exception("Traceparent format is incorrect")
-
-        return True
+        return bool(re.match("^[\da-f]{2}-[\da-f]{32}-[\da-f]{16}-[\da-f]{2}$", traceparent))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,7 +84,7 @@ class ClientTest(FaunaTestCase):
     os.environ["PATH"] = originalPath
 
   def test_tags_header(self):
-    self.client.observer = lambda rr: self.assertEqual(rr.response_headers["x-fauna-tags"], "baz=biz,foo=bar")
+    self.client.observer = lambda rr: self.assertCountEqual(rr.response_headers["x-fauna-tags"].split(","), ["foo=bar", "baz=biz"])
     test_tags = {
       "foo": "bar",
       "baz": "biz",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import platform
 import random
 import string
 from faunadb.client import FaunaClient
-from faunadb.errors import UnexpectedError
+from faunadb.errors import UnexpectedError, BadRequest
 from tests.helpers import FaunaTestCase
 from faunadb import __version__ as pkg_version, __api_version__ as api_version
 
@@ -100,8 +100,8 @@ class ClientTest(FaunaTestCase):
       ''.join(random.choice(string.ascii_lowercase) for _ in range(41)),
     ]
     for key in invalid_keys:
-      self.assertRaisesRegexCompat(Exception,
-                                   "One or more tag keys are invalid",
+      self.assertRaisesRegexCompat(BadRequest,
+                                   "invalid (tags|key)",
                                    lambda: self.client.query({}, tags={ key: "value" }))
 
   def test_invalid_tags_values(self):
@@ -111,29 +111,29 @@ class ClientTest(FaunaTestCase):
       ''.join(random.choice(string.ascii_lowercase) for _ in range(81)),
     ]
     for value in invalid_values:
-      self.assertRaisesRegexCompat(Exception,
-                                   "One or more tag values are invalid",
+      self.assertRaisesRegexCompat(BadRequest,
+                                   "invalid (tags|value)",
                                    lambda: self.client.query({}, tags={ "key": value }))
 
   def test_too_many_tags(self):
     too_many_keys = [ (''.join(random.choice(string.ascii_lowercase) for _ in range(10))) for _ in range(30) ]
     too_many_tags = { k: "value" for k in too_many_keys }
-    self.assertRaisesRegexCompat(Exception,
-                                 "Tags header only supports up to 25 key-value pairs",
+    self.assertRaisesRegexCompat(BadRequest,
+                                 "too many tags",
                                  lambda: self.client.query({}, tags=too_many_tags))
 
   def test_traceparent_header(self):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
     token2 = ''.join(random.choice(string.hexdigits.lower()) for _ in range(16))
+    req_tp = "00-%s-%s-01"%(token, token2)
     self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], "^00-%s-\w{16}-\d{2}$"%(token))
-    self.client.query({}, traceparent="00-%s-%s-01"%(token, token2))
+    self.client.query({}, traceparent=req_tp)
 
     self.client.observer = None
 
   def test_invalid_traceparent_header(self):
-    self.assertRaisesRegexCompat(Exception,
-                                 "Traceparent format is incorrect",
-                                 lambda: self.client.query({}, traceparent="foo"))
+    self.client.observer = lambda rr: self.assertIsNotNone(rr.response_headers["traceparent"]) and not self.assertRegexCompat(".*foo.*", rr.response_headers["traceparent"])
+    self.client.query({}, traceparent="foo")
 
   def test_empty_traceparent_header(self):
     tp_header = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,7 +125,7 @@ class ClientTest(FaunaTestCase):
   def test_traceparent_header(self):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
     token2 = ''.join(random.choice(string.hexdigits.lower()) for _ in range(16))
-    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"^00-{token}-\w{{16}}-\d{{2}}$")
+    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"\A00-{token}-\w{{16}}-\d{{2}}\z")
     self.client.query({}, traceparent=f"00-{token}-{token2}-01")
 
     self.client.observer = None
@@ -148,7 +148,7 @@ class ClientTest(FaunaTestCase):
     self.client.observer = _test_and_save_traceparent
     self.client.query({}, traceparent=None)
 
-    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"^00-{tp_part}-\w{{16}}-\d{{2}}$")
+    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"\A00-{tp_part}-\w{{16}}-\d{{2}}\z")
     self.client.query({}, traceparent=tp_header)
 
     self.client.observer = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -101,8 +101,8 @@ class ClientTest(FaunaTestCase):
     ]
     for key in invalid_keys:
       self.assertRaisesRegexCompat(Exception,
-                             "One or more tag keys are invalid",
-                             lambda: self.client.query({}, tags={ key: "value" }))
+                                   "One or more tag keys are invalid",
+                                   lambda: self.client.query({}, tags={ key: "value" }))
 
   def test_invalid_tags_values(self):
     invalid_values = [
@@ -112,15 +112,15 @@ class ClientTest(FaunaTestCase):
     ]
     for value in invalid_values:
       self.assertRaisesRegexCompat(Exception,
-                             "One or more tag values are invalid",
-                             lambda: self.client.query({}, tags={ "key": value }))
+                                   "One or more tag values are invalid",
+                                   lambda: self.client.query({}, tags={ "key": value }))
 
   def test_too_many_tags(self):
     too_many_keys = [ (''.join(random.choice(string.ascii_lowercase) for _ in range(10))) for _ in range(30) ]
     too_many_tags = { k: "value" for k in too_many_keys }
     self.assertRaisesRegexCompat(Exception,
-                           "Tags header only supports up to 25 key-value pairs",
-                           lambda: self.client.query({}, tags=too_many_tags))
+                                 "Tags header only supports up to 25 key-value pairs",
+                                 lambda: self.client.query({}, tags=too_many_tags))
 
   def test_traceparent_header(self):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
@@ -132,8 +132,8 @@ class ClientTest(FaunaTestCase):
 
   def test_invalid_traceparent_header(self):
     self.assertRaisesRegexCompat(Exception,
-                           "Traceparent format is incorrect",
-                           lambda: self.client.query({}, traceparent="foo"))
+                                 "Traceparent format is incorrect",
+                                 lambda: self.client.query({}, traceparent="foo"))
 
   def test_empty_traceparent_header(self):
     tp_header = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,7 +100,7 @@ class ClientTest(FaunaTestCase):
       ''.join(random.choice(string.ascii_lowercase) for _ in range(41)),
     ]
     for key in invalid_keys:
-      self.assertRaisesRegex(Exception,
+      self.assertRaisesRegexCompat(Exception,
                              "One or more tag keys are invalid",
                              lambda: self.client.query({}, tags={ key: "value" }))
 
@@ -111,27 +111,27 @@ class ClientTest(FaunaTestCase):
       ''.join(random.choice(string.ascii_lowercase) for _ in range(81)),
     ]
     for value in invalid_values:
-      self.assertRaisesRegex(Exception,
+      self.assertRaisesRegexCompat(Exception,
                              "One or more tag values are invalid",
                              lambda: self.client.query({}, tags={ "key": value }))
 
   def test_too_many_tags(self):
     too_many_keys = [ (''.join(random.choice(string.ascii_lowercase) for _ in range(10))) for _ in range(30) ]
     too_many_tags = { k: "value" for k in too_many_keys }
-    self.assertRaisesRegex(Exception,
+    self.assertRaisesRegexCompat(Exception,
                            "Tags header only supports up to 25 key-value pairs",
                            lambda: self.client.query({}, tags=too_many_tags))
 
   def test_traceparent_header(self):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
     token2 = ''.join(random.choice(string.hexdigits.lower()) for _ in range(16))
-    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"^00-{token}-\w{{16}}-\d{{2}}$")
+    self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], f"^00-{token}-\w{{16}}-\d{{2}}$")
     self.client.query({}, traceparent=f"00-{token}-{token2}-01")
 
     self.client.observer = None
 
   def test_invalid_traceparent_header(self):
-    self.assertRaisesRegex(Exception,
+    self.assertRaisesRegexCompat(Exception,
                            "Traceparent format is incorrect",
                            lambda: self.client.query({}, traceparent="foo"))
 
@@ -148,7 +148,7 @@ class ClientTest(FaunaTestCase):
     self.client.observer = _test_and_save_traceparent
     self.client.query({}, traceparent=None)
 
-    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"^00-{tp_part}-\w{{16}}-\d{{2}}$")
+    self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], f"^00-{tp_part}-\w{{16}}-\d{{2}}$")
     self.client.query({}, traceparent=tp_header)
 
     self.client.observer = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,7 +125,7 @@ class ClientTest(FaunaTestCase):
   def test_traceparent_header(self):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
     token2 = ''.join(random.choice(string.hexdigits.lower()) for _ in range(16))
-    self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], f"^00-{token}-\w{{16}}-\d{{2}}$")
+    self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], "^00-%s-\w{16}-\d{2}$"%(token))
     self.client.query({}, traceparent=f"00-{token}-{token2}-01")
 
     self.client.observer = None
@@ -148,7 +148,7 @@ class ClientTest(FaunaTestCase):
     self.client.observer = _test_and_save_traceparent
     self.client.query({}, traceparent=None)
 
-    self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], f"^00-{tp_part}-\w{{16}}-\d{{2}}$")
+    self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], "^00-%s-\w{16}-\d{2}$"%(tp_part))
     self.client.query({}, traceparent=tp_header)
 
     self.client.observer = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,7 +125,7 @@ class ClientTest(FaunaTestCase):
   def test_traceparent_header(self):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
     token2 = ''.join(random.choice(string.hexdigits.lower()) for _ in range(16))
-    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"\A00-{token}-\w{{16}}-\d{{2}}\z")
+    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"^00-{token}-\w{{16}}-\d{{2}}$")
     self.client.query({}, traceparent=f"00-{token}-{token2}-01")
 
     self.client.observer = None
@@ -148,7 +148,7 @@ class ClientTest(FaunaTestCase):
     self.client.observer = _test_and_save_traceparent
     self.client.query({}, traceparent=None)
 
-    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"\A00-{tp_part}-\w{{16}}-\d{{2}}\z")
+    self.client.observer = lambda rr: self.assertRegex(rr.response_headers["traceparent"], f"^00-{tp_part}-\w{{16}}-\d{{2}}$")
     self.client.query({}, traceparent=tp_header)
 
     self.client.observer = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -97,7 +97,7 @@ class ClientTest(FaunaTestCase):
     invalid_keys = [
       "foo bar",
       "foo*bar",
-      ''.join(random.choice(string.ascii_lowercase) for _ in range(45)),
+      ''.join(random.choice(string.ascii_lowercase) for _ in range(41)),
     ]
     for key in invalid_keys:
       self.assertRaisesRegex(Exception,
@@ -108,7 +108,7 @@ class ClientTest(FaunaTestCase):
     invalid_values = [
       "foo bar",
       "foo*bar",
-      ''.join(random.choice(string.ascii_lowercase) for _ in range(85)),
+      ''.join(random.choice(string.ascii_lowercase) for _ in range(81)),
     ]
     for value in invalid_values:
       self.assertRaisesRegex(Exception,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,7 +126,7 @@ class ClientTest(FaunaTestCase):
     token = ''.join(random.choice(string.hexdigits.lower()) for _ in range(32))
     token2 = ''.join(random.choice(string.hexdigits.lower()) for _ in range(16))
     self.client.observer = lambda rr: self.assertRegexCompat(rr.response_headers["traceparent"], "^00-%s-\w{16}-\d{2}$"%(token))
-    self.client.query({}, traceparent=f"00-{token}-{token2}-01")
+    self.client.query({}, traceparent="00-%s-%s-01"%(token, token2))
 
     self.client.observer = None
 


### PR DESCRIPTION
This change adds two new optional parameters to the `FaunaClient.query` function: `tags` and `traceparent`, which map to the `x-fauna-tags` and `traceparent` headers, respectively.

`tags` is expected to be a dictionary with no more than 25 entries, with each key being at most 40 characters of `[a-z0-9_]`. Each value can be up to 80 of the same set of characters.

`traceparent` is a [W3C-compliant](https://www.w3.org/TR/trace-context/) `traceparent` header; if it is passed as `None`, then the server will generate and reply with a new `traceparent` header, which can then be acquired from the `RequestResult` with an `observer` function/lambda and added to subsequent calls.

Test cases have been added to cover both happy-path and error scenarios.