### PR TITLE
Remove 3.10 from main test pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -40,7 +40,7 @@ groups:
       - release
   - name: staging-tests
     jobs:
-      - run-staging-tests
+      - run-3.10-tests
 
 jobs:
   - name: release
@@ -78,14 +78,14 @@ jobs:
       - put: fauna-python-repository-docs
         params:
           repository: fauna-python-repository-updated-docs
-  - name: run-staging-tests
+  - name: run-3.10-tests
     serial: true
     public: false
     plan:
       - get: fauna-python-repository-staging
 
       - task: integration-tests
-        file: fauna-python-repository-staging/concourse/tasks/integration-tests.yml
+        file: fauna-python-repository-staging/concourse/tasks/integration-tests-310.yml
         privileged: true
         input_mapping:
           { fauna-python-repository: fauna-python-repository-staging }

--- a/concourse/tasks/integration-tests-310.yml
+++ b/concourse/tasks/integration-tests-310.yml
@@ -21,11 +21,7 @@ run:
     - -ceu
     - |
       # start containers
-      docker-compose -f fauna-python-repository/concourse/tasks/integration.yml run tests-39
-      docker-compose -f fauna-python-repository/concourse/tasks/integration.yml run tests-38
-      docker-compose -f fauna-python-repository/concourse/tasks/integration.yml run tests-37
-      docker-compose -f fauna-python-repository/concourse/tasks/integration.yml run tests-36
-      docker-compose -f fauna-python-repository/concourse/tasks/integration.yml run tests-35
+      docker-compose -f fauna-python-repository/concourse/tasks/integration.yml run tests-310
       # stop and remove containers
       docker-compose -f fauna-python-repository/concourse/tasks/integration.yml down
       # remove volumes


### PR DESCRIPTION
Looks like setting up the `staging-tests` included adding v3.10 to the main pipeline, which we don't support yet.  This change adds a new task definition for just 3.10 and removes 3.10 from the critical path.