### PR TITLE
[FE-2401] upgrade to 3.10. hyper -> httpx, update stream tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
 
       - run:
           name: Install codecov
-          command:  |
+          command: |
             sudo pip install codecov
 
       - run:
@@ -54,12 +54,28 @@ commands:
 
       - store_test_results:
           path: results/
-        
+
       - store_artifacts:
           path: results/
           destination: tr1
 
 jobs:
+  core-stable-310:
+    executor:
+      name: core
+      python_version: "3.10"
+      version: stable
+    steps:
+      - build_and_test
+
+  core-nightly-310:
+    executor:
+      name: core
+      python_version: "3.10"
+      version: nightly
+    steps:
+      - build_and_test
+
   core-stable-39:
     executor:
       name: core
@@ -124,27 +140,14 @@ jobs:
     steps:
       - build_and_test
 
-  core-stable-35:
-    executor:
-      name: core
-      python_version: "3.5"
-      version: stable
-    steps:
-      - build_and_test
-
-  core-nightly-35:
-    executor:
-      name: core
-      python_version: "3.5"
-      version: nightly
-    steps:
-      - build_and_test
-
-
 workflows:
   version: 2
   build_and_test:
     jobs:
+      - core-stable-310:
+          context: faunadb-drivers
+      - core-nightly-310:
+          context: faunadb-drivers
       - core-stable-39:
           context: faunadb-drivers
       - core-nightly-39:
@@ -160,8 +163,4 @@ workflows:
       - core-stable-36:
           context: faunadb-drivers
       - core-nightly-36:
-          context: faunadb-drivers
-      - core-stable-35:
-          context: faunadb-drivers
-      - core-nightly-35:
           context: faunadb-drivers

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,28 @@
+# Take in a runtime image to use for the base system
+# Expects an alpine-based image
+ARG RUNTIME_IMAGE
+
+# Use the docker image provided via build arg
+FROM $RUNTIME_IMAGE
+
+# Install the libraries we need for python and dockerize
+RUN apk add --no-cache curl make openssl
+
+# Copy in the dockerize utility
+ARG DOCKERIZE_VERSION=0.6.1
+RUN curl -sL https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION/dockerize-linux-amd64-v$DOCKERIZE_VERSION.tar.gz | tar -xzC /usr/local/bin
+
+
+# Copy project into the image
+COPY . /fauna/faunadb-python
+
+# Shift over to the project and install the dependencies
+WORKDIR /fauna/faunadb-python
+RUN pip install . .[test]
+
+# Define the default variables for the tests
+ENV FAUNA_ROOT_KEY=secret FAUNA_DOMAIN=localhost FAUNA_SCHEME=http FAUNA_PORT=8443 FAUNA_TIMEOUT=30s
+
+# Run the tests (after target database is up)
+# CMD ["make", "docker-wait", "test"]
+CMD ["make", "test"]

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ lint-faunadb:
 lint-tests:
 	pylint tests --reports=n --indent-string='  ' --indent-after-paren=2 --disable=invalid-name,locally-disabled,missing-docstring,too-few-public-methods,too-many-arguments,no-member,no-self-use,protected-access,relative-import,too-many-public-methods
 
+docker-test:
+	docker build -f Dockerfile.test -t faunadb-python-test:latest --build-arg RUNTIME_IMAGE=$(RUNTIME_IMAGE) .
+	docker run $(DOCKER_RUN_FLAGS) faunadb-python-test:latest
+
 jenkins-test:
 	python -Wd -m nose2 --with-coverage --coverage-report xml --plugin nose2.plugins.junitxml --junit-xml && mv coverage.xml nose2-junit.xml results/ || { code=$$?; mv coverage.xml nose2-junit.xml results/; exit $$code; }
 

--- a/faunadb/streams/client.py
+++ b/faunadb/streams/client.py
@@ -9,12 +9,12 @@ except ImportError:
 
 from faunadb._json import parse_json_or_none, stream_content_to_json, to_json
 from faunadb.request_result import RequestResult
-from hyper import HTTP20Connection
+import httpx
 
 from .errors import StreamError
 from .events import Error, parse_stream_request_result_or_none
 
-VALID_FIELDS = {"diff", "prev", "document", "action", "index"}
+VALID_FIELDS = {"diff", "prev", "document", "action"}
 
 
 class Connection(object):
@@ -24,7 +24,7 @@ class Connection(object):
     subscription.
 
     Current limitations:
-    Python requests module uses HTTP1; hyper is used for HTTP/2
+    Python requests module uses HTTP1; httpx is used for HTTP/2
     """
 
     def __init__(self, client, expression, options):
@@ -45,10 +45,10 @@ class Connection(object):
         self._query = expression
         self._data = to_json(expression).encode()
         try:
-            self.conn = HTTP20Connection(
-                self._client.domain, port=self._client.port, enable_push=True)
-        except Exception as e:
-            raise StreamError(e)
+            base_url = "https://%s:%s" % (self._client.domain, self._client.port)
+            self.conn=httpx.Client(http2=True,http1=False, base_url=base_url, timeout=None)
+        except Exception as error_msg:
+            raise StreamError(error_msg)
 
     def close(self):
         """
@@ -76,47 +76,47 @@ class Connection(object):
             if isinstance(self._fields, list):
                 url_params = "?%s" % (
                     urlencode({'fields': ",".join(self._fields)}))
-            id = self.conn.request("POST", "/stream%s" %
-                                   (url_params), body=self._data, headers=headers)
+            id = self.conn.stream("POST", "/stream%s" %
+                                  (url_params), data=self._data, headers=dict(headers))
+            
             self._state = 'open'
             self._event_loop(id, on_event, start_time)
-        except Exception as e:
+        except Exception as error_msg:
             if callable(on_event):
-                on_event(Error(e), None)
+                on_event(Error(error_msg), None)
 
     def _event_loop(self, stream_id, on_event, start_time):
         """ Event loop for the stream. """
-        response = self.conn.get_response(stream_id)
-        if 'x-txn-time' in response.headers:
-            self._client.sync_last_txn_time(
-                int(response.headers['x-txn-time'][0].decode()))
-        try:
-            buffer = ''
-            for push in response.read_chunked():
+        with stream_id as response:
+            if 'x-txn-time' in response.headers:
+                self._client.sync_last_txn_time(int(response.headers['x-txn-time']))
+            try:
+                buffer = ''
+                for push in response.iter_bytes():
 
-                try:
-                    chunk = push.decode()
-                    buffer += chunk
-                except:
-                    continue
+                    try:
+                        chunk = push.decode()
+                        buffer += chunk
+                    except:
+                        continue
 
-                result = stream_content_to_json(buffer)
-                buffer = result["buffer"]
+                    result = stream_content_to_json(buffer)
+                    buffer = result["buffer"]
 
-                for value in result["values"]:
-                    request_result = self._stream_chunk_to_request_result(
-                        response, value["raw"], value["content"], start_time, time())
-                    event = parse_stream_request_result_or_none(request_result)
+                    for value in result["values"]:
+                        request_result = self._stream_chunk_to_request_result(
+                            response, value["raw"], value["content"], start_time, time())
+                        event = parse_stream_request_result_or_none(request_result)
 
-                    if event is not None and hasattr(event, 'txn'):
-                        self._client.sync_last_txn_time(int(event.txn))
-                    on_event(event, request_result)
-                    if self._client.observer is not None:
-                        self._client.observer(request_result)
-        except Exception as e:
-            self.error = e
-            self.close()
-            on_event(Error(e), None)
+                        if event is not None and hasattr(event, 'txn'):
+                            self._client.sync_last_txn_time(int(event.txn))
+                        on_event(event, request_result)
+                        if self._client.observer is not None:
+                            self._client.observer(request_result)
+            except Exception as error_msg:
+                self.error = error_msg
+                self.close()
+                on_event(Error(error_msg), None)
 
     def _stream_chunk_to_request_result(self, response, raw, content, start_time, end_time):
         """ Converts a stream chunk to a RequestResult. """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+iso8601==1.0.2
+requests==2.27.1
+future==0.18.2
+httpx[http2]==0.21.3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
     "iso8601",
     "requests",
     "future",
-    "hyper"
+    "httpx[http2]"
 ]
 
 tests_requires = [

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -178,6 +178,7 @@ class StreamTest(FaunaTestCase):
             self.assertTrue(isinstance(event.error, BadRequest))
             self.assertEqual(event.error._get_description(),
                              'Expected a Document Ref or Version, or a Set Ref, got String.')
+            stream.close();
         stream=self.stream_sync('invalid stream', on_error=on_error )
         stream.start()
 


### PR DESCRIPTION
### Problem
* Need to support 3.10, `hyper` library is not supported

### Solution
* Use `httpx` in place of hyper
* Update stream tests to handle `httpx` way of closing a stream via setting the state instead of closing the `self.conn` object.
* Also added the Dockerfile test back in to the repo for local testing.

Please read this issue for more details on reasoning for the change:
https://faunadb.atlassian.net/browse/FE-2401
