### PR TITLE
Handle contended transaction errors

### DIFF
--- a/faunadb/errors.py
+++ b/faunadb/errors.py
@@ -35,6 +35,8 @@ class FaunaError(Exception):
             raise PermissionDenied(request_result)
         elif code == codes.not_found:
             raise NotFound(request_result)
+        elif code == codes.conflict:
+            raise ContendedTransaction(request_result)
         elif code == codes.internal_server_error:
             raise InternalError(request_result)
         elif code == codes.unavailable:
@@ -91,6 +93,11 @@ class PermissionDenied(HttpError):
 
 class NotFound(HttpError):
     """HTTP 404 error."""
+    pass
+
+
+class ContendedTransaction(HttpError):
+    """HTTP 409 error."""
     pass
 
 


### PR DESCRIPTION
Ticket: [FE-3205](https://faunadb.atlassian.net/browse/FE-3205)
closes #268  

# Problem
409 errors are not being caught by the driver.  It is expected that the client can handle 409s in their own specific ways.

# Solution
Add a new ContendedTransaction class and use it if the error code is 409

# Out of scope
testing for 409 errors. This is nontrivial, since we will need to add capacity to run many requests asynchronously.

[FE-3205]: https://faunadb.atlassian.net/browse/FE-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ